### PR TITLE
Travis-CI: Test the upstream neo-python dev branch with the current neocore code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ language: python
 python:
   - 3.5
 
+addons:
+  apt:
+    packages:
+    - libleveldb-dev
+    - libsqlite3-dev
+
 install:
   - pip install -r requirements.txt
   - pip install -r requirements_dev.txt
@@ -19,19 +25,9 @@ script:
   - cd neo-python
   - pwd
   - git checkout origin/development -b development
-#   - python3 -m venv venv
-#   - source venv/bin/activate
-  - which python
-  - which python3
-  - which pip
-  - which pip3.5
-  - python -V
-  - python3 -V
-  - pip -V
-  - pip3.5 -V
-  - pip3.5 install -r requirements.txt
-  - yes | pip3.5 uninstall neocore
-  - pip3.5 install -e ../
+  - pip install -r requirements.txt
+  - yes | pip uninstall neocore
+  - pip install -e ../
   - coverage run -m unittest discover neo
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,20 @@ install:
   - pip install coveralls
 
 script:
+  # run internal tests
   - coverage run --source neocore setup.py test
   - pycodestyle neocore tests
+
+  # now test the upstream neo-python dev branch with the current neocore code
+  - git clone https://github.com/CityOfZion/neo-python.git
+  - cd neo-python
+  - git checkout origin/development -b development
+  - python3 -m venv venv
+  - source venv/bin/activate
+  - pip install -r requirements.txt
+  - yes | pip uninstall neocore
+  - pip install -e ../
+  - coverage run -m unittest discover neo
 
 after_success:
  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,16 @@ script:
   - git checkout origin/development -b development
   - python3 -m venv venv
   - source venv/bin/activate
-  - pip install -r requirements.txt
-  - yes | pip uninstall neocore
-  - pip install -e ../
+  - which python3
+  - which pip
+  - which pip3
+  - python -V
+  - python3 -V
+  - pip -V
+  - pip3 -V
+  - pip3 install -r requirements.txt
+  - yes | pip3 uninstall neocore
+  - pip3 install -e ../
   - coverage run -m unittest discover neo
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,19 +17,21 @@ script:
   # now test the upstream neo-python dev branch with the current neocore code
   - git clone https://github.com/CityOfZion/neo-python.git
   - cd neo-python
+  - pwd
   - git checkout origin/development -b development
-  - python3 -m venv venv
-  - source venv/bin/activate
+#   - python3 -m venv venv
+#   - source venv/bin/activate
+  - which python
   - which python3
   - which pip
-  - which pip3
+  - which pip3.5
   - python -V
   - python3 -V
   - pip -V
-  - pip3 -V
-  - pip3 install -r requirements.txt
-  - yes | pip3 uninstall neocore
-  - pip3 install -e ../
+  - pip3.5 -V
+  - pip3.5 install -r requirements.txt
+  - yes | pip3.5 uninstall neocore
+  - pip3.5 install -e ../
   - coverage run -m unittest discover neo
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,11 @@ script:
   # now test the upstream neo-python dev branch with the current neocore code
   - git clone https://github.com/CityOfZion/neo-python.git
   - cd neo-python
-  - pwd
   - git checkout origin/development -b development
   - pip install -r requirements.txt
   - yes | pip uninstall neocore
   - pip install -e ../
-  - coverage run -m unittest discover neo
+  - python -m unittest discover neo
 
 after_success:
  - coveralls


### PR DESCRIPTION
This PR adds another test run to travis-ci: it clones neo-python and makes sure the current `neocore` code works with the neo-python development branch.

