### PR TITLE
fix WriteFixedString and up BinaryWriter coverage to 100%

### DIFF
--- a/neocore/IO/BinaryWriter.py
+++ b/neocore/IO/BinaryWriter.py
@@ -98,8 +98,6 @@ class BinaryWriter(object):
         if unhex:
             try:
                 value = binascii.unhexlify(value)
-            except TypeError:
-                pass
             except binascii.Error:
                 pass
         return self.stream.write(value)
@@ -384,7 +382,7 @@ class BinaryWriter(object):
         """
         towrite = value.encode('utf-8')
         slen = len(towrite)
-        if len(value) > slen:
+        if slen > length:
             raise Exception("string longer than fixed length: %s " % length)
         self.WriteBytes(towrite)
         diff = length - slen


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**
- get coverage of `BinaryWriter` up to 100%
- fix `WriteFixedString` error handling

**How did you solve this problem?**
write code + tests

**How did you make sure your solution works?**
`make lint && make test && make coverage`

**Did you add any tests?**
yes

**Are there any special changes in the code that we should be aware of?**
yes/no, see my own review
