### PR TITLE
Clarify UIntBase error message

### DIFF
--- a/neocore/UIntBase.py
+++ b/neocore/UIntBase.py
@@ -15,7 +15,7 @@ class UIntBase(SerializableMixin):
 
         else:
             if len(data) != num_bytes:
-                raise Exception("Invalid UInt")
+                raise Exception("Invalid UInt - data length {} != specified num_bytes {}".format(len(data), num_bytes))
 
             if type(data) is bytes:
                 self.Data = bytearray(data)

--- a/neocore/UIntBase.py
+++ b/neocore/UIntBase.py
@@ -15,7 +15,7 @@ class UIntBase(SerializableMixin):
 
         else:
             if len(data) != num_bytes:
-                raise Exception("Invalid UInt - data length {} != specified num_bytes {}".format(len(data), num_bytes))
+                raise Exception("Invalid UInt: data length {} != specified num_bytes {}".format(len(data), num_bytes))
 
             if type(data) is bytes:
                 self.Data = bytearray(data)


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**
This one has been bothering me for a while so it's about time to clarify it. The error message when providing data that is not long enough is not self explanatory.

```
UInt256(data=bytearray.fromhex('aabb'))
UInt256(data=b'aa' * 32)
```
both produce
> Invalid UInt

 A more verbose error message can clarify what is wrong about the data.

**How did you solve this problem?**
make the error message more verbose.

_Case 1_
> Invalid UInt - data length 2 != specified num_bytes 32

It's immediately clear I'm not providing enough data

_Case 2_
> Invalid UInt - data length 64 != specified num_bytes 32

It becomes clear that the format I'm providing data in isn't valid and I have to convert it to raw bytes.

**How did you make sure your solution works?**
 ran some manual tests in Ipython.

**Did you add any tests?**
no

**Are there any special changes in the code that we should be aware of?**
no
