### PR TITLE
omit ECCurve.py from coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 
 script:
   # run internal tests
-  - coverage run --source neocore setup.py test
+  - coverage run --omit neocore/Cryptography/ECCurve.py --source neocore setup.py test
   - pycodestyle neocore tests
 
   # now test the upstream neo-python dev branch with the current neocore code

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ test: ## run tests quickly with the default Python
 
 coverage: ## check code coverage quickly with the default Python
 	coverage run --source neocore setup.py test
-	coverage report -m
+	coverage report -m --omit=neocore/Cryptography/ECCurve.py
 	coverage html
 	$(BROWSER) htmlcov/index.html
 


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**
`ECCurve.py` is currently hardly covered, but is proven to be functional by real world usage. #21 was initiated to look at a maintained ECDSA package to replace the homebrew instance, but we could not conclude for now.

This exclusion suggestion has been discussed with @localhuman on slack and we agreed to keep #21 open to stay reminded of the fact that we 1) have to replace the module some day or 2) fix coverage.

**How did you solve this problem?**
exclude the file from coverage by updating the Make file

**How did you make sure your solution works?**
make test & make coverage

**Did you add any tests?**
no

**Are there any special changes in the code that we should be aware of?**
no
