### PR TITLE
Allow change to address version

### DIFF
--- a/neocore/Cryptography/Helper.py
+++ b/neocore/Cryptography/Helper.py
@@ -18,6 +18,7 @@ long = int
 
 ADDRESS_VERSION = 23
 
+
 def double_sha256(ba):
     """
     Perform two SHA256 operations on the input.

--- a/neocore/Cryptography/Helper.py
+++ b/neocore/Cryptography/Helper.py
@@ -16,6 +16,7 @@ import base58
 
 long = int
 
+ADDRESS_VERSION = 23
 
 def double_sha256(ba):
     """
@@ -70,7 +71,7 @@ def scripthash_to_address(scripthash):
     Returns:
         str: base58 encoded string representing the wallet address.
     """
-    sb = bytearray([23]) + scripthash
+    sb = bytearray([ADDRESS_VERSION]) + scripthash
     c256 = bin_dbl_sha256(sb)[0:4]
     outb = sb + bytearray(c256)
     return base58.b58encode(bytes(outb))

--- a/tests/test_cryptography.py
+++ b/tests/test_cryptography.py
@@ -56,6 +56,17 @@ class HelperTestCase(TestCase):
         self.assertEqual(scripthash, expected_scripthash)
         self.assertEqual(address, expected_address)
 
+    def test_scripthash_to_address_with_alternative_version(self):
+        default_address_version = Helper.ADDRESS_VERSION
+        Helper.ADDRESS_VERSION = 42
+        scripthash = binascii.unhexlify('42112378ffa32c4c65d513aa350689dff6381154')
+        expected_address = 'J1DfV2jS511SMtP6dH5ckr3Nwf26kbFx7s'
+        address = Helper.scripthash_to_address(scripthash)
+
+        self.assertEqual(address, expected_address)
+
+        Helper.ADDRESS_VERSION = default_address_version
+
     def test_publickey_to_scripthash(self):
         expected_scripthash = binascii.unhexlify('79ecf967a02f9bdbd147fc97b18efd7877d27f78')
         priv_key = KeyPair.PrivateKeyFromWIF('L44B5gGEpqEDRS9vVPz7QT35jcBG2r3CZwSwQ4fCewXAhAhqGVpP')


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**

Address version is hard coded to `23`, but is intended to be configurable in `protocol.json`.

I'm working with a neo fork that uses a different address version.

**How did you solve this problem?**

Added a variable `ADDRESS_VERSION` to `Helper` module that can be overridden.

**How did you make sure your solution works?**

I added a unit test to demonstrate.

**Did you add any tests?**

Of course!

**Are there any special changes in the code that we should be aware of?**

I'll be opening a PR for `neo-python` that updates this from Settings/`protocol.json`