### PR TITLE
add ToJsonString method to match NEO cli output

### DIFF
--- a/neocore/Fixed8.py
+++ b/neocore/Fixed8.py
@@ -135,7 +135,7 @@ class Fixed8:
     def ToString(self):
         return str(self.value / Fixed8.D)
 
-    def ToJsonString(self):
+    def ToNeoJsonString(self):
         return self.ToString().rstrip('.0')
 
     def __str__(self):

--- a/neocore/Fixed8.py
+++ b/neocore/Fixed8.py
@@ -11,7 +11,6 @@ import math
 
 
 class Fixed8:
-
     value = 0
 
     D = 100000000
@@ -135,6 +134,9 @@ class Fixed8:
 
     def ToString(self):
         return str(self.value / Fixed8.D)
+
+    def ToJsonString(self):
+        return self.ToString().rstrip('.0')
 
     def __str__(self):
         return self.ToString()

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -179,9 +179,9 @@ class Fixed8TestCase(TestCase):
 
     def test_fixed8_tojsonstring(self):
         f8 = Fixed8.FromDecimal(1.0)
-        self.assertEqual("1", f8.ToJsonString())
+        self.assertEqual("1", f8.ToNeoJsonString())
         f8 = Fixed8.FromDecimal(1.10)
-        self.assertEqual("1.1", f8.ToJsonString())
+        self.assertEqual("1.1", f8.ToNeoJsonString())
 
 
 class BigIntegerTestCase(TestCase):

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -58,7 +58,6 @@ class Fixed8TestCase(TestCase):
         self.assertEqual(f3.value, 8)
 
     def test_fixed8_mod(self):
-
         f1 = Fixed8(10)
         f2 = Fixed8(5)
 
@@ -177,6 +176,12 @@ class Fixed8TestCase(TestCase):
         self.assertEqual(f8.ToInt(), 1)
         self.assertEqual(f8.ToString(), "1.0")
         self.assertTrue(isinstance(f8.ToString(), str))
+
+    def test_fixed8_tojsonstring(self):
+        f8 = Fixed8.FromDecimal(1.0)
+        self.assertEqual("1", f8.ToJsonString())
+        f8 = Fixed8.FromDecimal(1.10)
+        self.assertEqual("1.1", f8.ToJsonString())
 
 
 class BigIntegerTestCase(TestCase):


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
NEO cli outputs Fixed8 values in their JSON parser as follows:
```
8.0 -> "8"
8.123 -> "8.123"
8.120 -> "8.12"
```

where are the current `ToString` would print e.g `"8.0"`

**How did you solve this problem?**
add `ToJsonString` method

**How did you make sure your solution works?**
make lint 
make test
make coverage
**Did you add any tests?**
yes

**Did you run `make lint` and `make coverage`?**
yes
**Are there any special changes in the code that we should be aware of?**
no