### PR TITLE
Added ParseString method to UInt160/UInt256

### DIFF
--- a/neocore/UInt160.py
+++ b/neocore/UInt160.py
@@ -4,3 +4,13 @@ from neocore.UIntBase import UIntBase
 class UInt160(UIntBase):
     def __init__(self, data=None):
         super(UInt160, self).__init__(num_bytes=20, data=data)
+
+    @staticmethod
+    def ParseString(value):
+        if value[0:2] == '0x':
+            value = value[2:]
+        if not len(value) == 40:
+            raise Exception("Invalid UInt160 Format: %s chars != 40 chars" % len(value))
+        reversed_data = bytearray.fromhex(value)
+        reversed_data.reverse()
+        return UInt160(data=reversed_data)

--- a/neocore/UInt256.py
+++ b/neocore/UInt256.py
@@ -4,3 +4,13 @@ from neocore.UIntBase import UIntBase
 class UInt256(UIntBase):
     def __init__(self, data=None):
         super(UInt256, self).__init__(num_bytes=32, data=data)
+
+    @staticmethod
+    def ParseString(value):
+        if value[0:2] == '0x':
+            value = value[2:]
+        if not len(value) == 64:
+            raise Exception("Invalid UInt256 Format: %s chars != 64 chars" % len(value))
+        reversed_data = bytearray.fromhex(value)
+        reversed_data.reverse()
+        return UInt256(data=reversed_data)

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -449,6 +449,23 @@ class UInt160TestCase(TestCase):
             u1 = UInt160(b'12345')
 
 
+    def test_parse(self):
+        string = '0xd7678dd97c000be3f33e9362e673101bac4ca654'
+        uint160 = UInt160.ParseString(string)
+        self.assertIsInstance(uint160, UInt160)
+        self.assertEqual(uint160.To0xString(), string)
+
+        string = '5b7074e873973a6ed3708862f219a6fbf4d1c411'
+        uint160 = UInt160.ParseString(string)
+        self.assertIsInstance(uint160, UInt160)
+        self.assertEqual(uint160.ToString(), string)
+
+        string = '5b7074e873973a6ed3708862f219a6fbf4d1c41'
+        with self.assertRaises(Exception) as context:
+            uint160 = UInt160.ParseString(string)
+
+
+
 class UInt256TestCase(TestCase):
     def test_initialization(self):
         u0 = UInt256()
@@ -463,3 +480,20 @@ class UInt256TestCase(TestCase):
 
         with self.assertRaises(Exception):
             u1 = UInt256('12345678901234567890123456789012')
+
+
+    def test_parse(self):
+        string = '0xcedb5c4e24b1f6fc5b239f2d1049c3229ad5ed05293c696b3740dc236c3f41b4'
+        uint256 = UInt256.ParseString(string)
+        self.assertIsInstance(uint256, UInt256)
+        self.assertEqual(uint256.To0xString(), string)
+
+        string = '9410bd44beb7d6febc9278b028158af2781fcfb40cf2c6067b3525d24eff19f6'
+        uint256 = UInt256.ParseString(string)
+        self.assertIsInstance(uint256, UInt256)
+        self.assertEqual(uint256.ToString(), string)
+
+        string = '9410bd44beb7d6febc9278b028158af2781fcfb40cf2c6067b3525d24eff19f'
+        with self.assertRaises(Exception) as context:
+            uint256 = UInt256.ParseString(string)
+

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -448,7 +448,6 @@ class UInt160TestCase(TestCase):
         with self.assertRaises(Exception):
             u1 = UInt160(b'12345')
 
-
     def test_parse(self):
         string = '0xd7678dd97c000be3f33e9362e673101bac4ca654'
         uint160 = UInt160.ParseString(string)
@@ -463,7 +462,6 @@ class UInt160TestCase(TestCase):
         string = '5b7074e873973a6ed3708862f219a6fbf4d1c41'
         with self.assertRaises(Exception) as context:
             uint160 = UInt160.ParseString(string)
-
 
 
 class UInt256TestCase(TestCase):
@@ -481,7 +479,6 @@ class UInt256TestCase(TestCase):
         with self.assertRaises(Exception):
             u1 = UInt256('12345678901234567890123456789012')
 
-
     def test_parse(self):
         string = '0xcedb5c4e24b1f6fc5b239f2d1049c3229ad5ed05293c696b3740dc236c3f41b4'
         uint256 = UInt256.ParseString(string)
@@ -496,4 +493,3 @@ class UInt256TestCase(TestCase):
         string = '9410bd44beb7d6febc9278b028158af2781fcfb40cf2c6067b3525d24eff19f'
         with self.assertRaises(Exception) as context:
             uint256 = UInt256.ParseString(string)
-


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

- adds standardized method to `UInt256/UInt160` to parse a string ( with optional `0x` prefix ) into a UInt256 or UInt160 object

**How did you make sure your solution works?**
- tests

**Did you add any tests?**
- yes

**Did you run `make lint` and `make coverage`?**
- yes

**Are there any special changes in the code that we should be aware of?**
- no