### PR TITLE
Dont unhex when writing var bytes

### DIFF
--- a/neocore/IO/BinaryWriter.py
+++ b/neocore/IO/BinaryWriter.py
@@ -352,7 +352,8 @@ class BinaryWriter(object):
         """
         length = len(value)
         self.WriteVarInt(length, endian)
-        return self.WriteBytes(value)
+
+        return self.WriteBytes(value, unhex=False)
 
     def WriteVarString(self, value, encoding="utf-8"):
         """


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- some byte representations of values will no longer get un-hexxed when they shouldn't be

**How did you make sure your solution works?**
- tests

**Did you run `make lint` and `make coverage`?**
- yes

