### PR TITLE
Add requirements.txt to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
 include README.rst
+include requirements.txt
 
 recursive-include neocore *
 recursive-include tests *


### PR DESCRIPTION
This fixes installing from a source distribution.
For example, `pip install --no-binary :all: neocore`

**What current issue(s) does this address, or what feature is it adding?**
This fixes building from source distribution.

**How did you solve this problem?**
I added a missing file to `MANIFEST.in`

**How did you make sure your solution works?**
I ran it.

**Did you add any tests?**
No

**Did you run `make lint` and `make coverage`?**
Yes

**Are there any special changes in the code that we should be aware of?**
No