### PR TITLE
Add scripthash_to_address

### DIFF
--- a/neocore/bin/cli.py
+++ b/neocore/bin/cli.py
@@ -31,6 +31,20 @@ def address_to_scripthash(address):
     # Return only the scripthash bytes
     return data[1:-4]
 
+def scripthash_to_address(address):
+    data = address.replace('0x','')
+
+    # Check format
+    if len(data) != 40:
+            raise ConversionError("Wrong format")
+    # Add prefix
+    data = b'\x17' + bytearray.fromhex(data)[::-1]
+
+    # Add checksum
+    data = data + hashlib.sha256(hashlib.sha256(data).digest()).digest()[:4]
+
+    # Return Address
+    return base58.b58encode(data)
 
 def main():
     parser = argparse.ArgumentParser()
@@ -41,6 +55,9 @@ def main():
 
     parser.add_argument("--address-to-scripthash", nargs=1, metavar="address",
                         help="Convert an address to scripthash")
+
+    parser.add_argument("--scripthash-to-address", nargs=1, metavar="scripthash",
+                        help="Convert scripthash to address")
 
     args = parser.parse_args()
     if len(sys.argv) == 1:
@@ -56,6 +73,13 @@ def main():
             print(e)
             exit(1)
 
+    if args.scripthash_to_address:
+        try:
+            address = scripthash_to_address(args.scripthash_to_address[0])
+            print(address)
+        except ConversionError as e:
+            print(e)
+            exit(1)
 
 if __name__ == "__main__":
     main()

--- a/neocore/bin/cli.py
+++ b/neocore/bin/cli.py
@@ -24,7 +24,7 @@ def address_to_scripthash(address):
     if not is_correct_signature:
         raise ConversionError("Invalid address: wrong signature byte")
 
-    # # Make sure the checksum is correct
+    # Make sure the checksum is correct
     if data[-4:] != hashlib.sha256(hashlib.sha256(data[:-4]).digest()).digest()[:4]:
         raise ConversionError("Invalid address: invalid checksum")
 
@@ -51,7 +51,7 @@ def main():
     if args.address_to_scripthash:
         try:
             scripthash = address_to_scripthash(args.address_to_scripthash[0])
-            print(scripthash)
+            print('Script Hash: 0x{} -- Python format: {!r}'.format(scripthash[::-1].hex(), scripthash))
         except ConversionError as e:
             print(e)
             exit(1)

--- a/neocore/bin/cli.py
+++ b/neocore/bin/cli.py
@@ -9,6 +9,7 @@ import hashlib
 
 from neocore import __version__
 from neocore.Cryptography.Crypto import Crypto
+from neocore.UInt160 import UInt160
 
 
 class ConversionError(Exception):
@@ -31,20 +32,12 @@ def address_to_scripthash(address):
     # Return only the scripthash bytes
     return data[1:-4]
 
-def scripthash_to_address(address):
-    data = address.replace('0x','')
+def scripthash_to_address(scripthash):
+    try:
+        return Crypto.ToAddress(UInt160.ParseString(scripthash))
+    except:
+        raise ConversionError("Wrong format")
 
-    # Check format
-    if len(data) != 40:
-            raise ConversionError("Wrong format")
-    # Add prefix
-    data = b'\x17' + bytearray.fromhex(data)[::-1]
-
-    # Add checksum
-    data = data + hashlib.sha256(hashlib.sha256(data).digest()).digest()[:4]
-
-    # Return Address
-    return base58.b58encode(data)
 
 def main():
     parser = argparse.ArgumentParser()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,8 +7,21 @@ class CliTestCase(TestCase):
     def test_address_to_scripthash(self):
         address = "AK2nJJpJr6o664CWJKi1QRXjqeic2zRp8y"
         scripthash = cli.address_to_scripthash(address)
-        self.assertEqual(len(scripthash), 20)
+        self.assertEqual(scripthash, b'#\xba\'\x03\xc52c\xe8\xd6\xe5"\xdc2 39\xdc\xd8\xee\xe9')
 
         address = "AK2nJJpJr6o664CWJKi1QRXjqeic2zRpxx"
         with self.assertRaises(cli.ConversionError):
             scripthash = cli.address_to_scripthash(address)
+
+    def test_scripthash_to_address(self):
+        scripthash = "0xe9eed8dc39332032dc22e5d6e86332c50327ba23"
+        address = cli.scripthash_to_address(scripthash)
+        self.assertEqual(address, "AK2nJJpJr6o664CWJKi1QRXjqeic2zRp8y")
+
+        scripthash = "e9eed8dc39332032dc22e5d6e86332c50327ba23"
+        address = cli.scripthash_to_address(scripthash)
+        self.assertEqual(address, "AK2nJJpJr6o664CWJKi1QRXjqeic2zRp8y")
+
+        scripthash = "0xe9eed8dc39332032dc22e5d6e86332c50327baxx"
+        with self.assertRaises(cli.ConversionError):
+            address = cli.scripthash_to_address(scripthash)


### PR DESCRIPTION
* Format **address_to_scripthash** output
```
> python3 cly.py --address-to-scripthash AKq8w9TCEwp2b9da8up8na9R57F1gEDUKf
Script Hash: 0x52e8def10107b89ac8c416a8148ba43f12837e2c -- Python format: b',~\x83\x12?\xa4\x8b\x14\xa8\x16\xc4\xc8\x9a\xb8\x07\x01\xf1\xde\xe8R'
```
* Add **scripthash_to_address**
```
> python3 cly.py --scripthash-to-address 0x52e8def10107b89ac8c416a8148ba43f12837e2c
AKq8w9TCEwp2b9da8up8na9R57F1gEDUKf
```