### PR TITLE
Use pycryptodome instead of pycrypto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ base58>=0.2.5
 bitcoin>=1.1.42
 mpmath>=1.0.0
 scrypt>=0.8.6
-pycrypto>=2.6.1
+pycryptodome>=3.5.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -27,7 +27,7 @@ pluggy==0.6.0
 py==1.5.2
 pycodestyle==2.3.1
 pycparser==2.18
-pycrypto==2.6.1
+pycryptodome==3.5.1
 pyflakes==1.6.0
 Pygments==2.2.0
 pytz==2017.3


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
pycrypto has not been updated in almost 4 years.
Many other packages use pycryptodome and are incompatible with pycryto. Installing neo-python-core side-by-side with such packages causes them to break.

**How did you solve this problem?**
Switch to pycryptodome.

**How did you make sure your solution works?**
Run tests

**Did you add any tests?**
No

**Did you run `make lint` and `make coverage`?**
yes

**Are there any special changes in the code that we should be aware of?**
Yes, this PR should probably not be merged until the same change is made to neo-python. Although this change will not break anything in neo-python, it could cause subsequent changes that do break neo-python to go unnoticed. neo-python is harder to test (and I'm not using it), so I did not submit a PR there yet.