### PR TITLE
make unhexlify in Crypto.VerifySignature optional

### DIFF
--- a/neocore/Cryptography/Crypto.py
+++ b/neocore/Cryptography/Crypto.py
@@ -126,7 +126,7 @@ class Crypto(object):
         return sig
 
     @staticmethod
-    def VerifySignature(message, signature, public_key):
+    def VerifySignature(message, signature, public_key, unhex=True):
         """
         Verify the integrity of the message.
 
@@ -145,11 +145,11 @@ class Crypto(object):
 
             public_key = pubkey_x + pubkey_y
 
-        m = message
-        try:
-            m = binascii.unhexlify(message)
-        except Exception as e:
-            logger.error("could not get m: %s" % e)
+        if unhex:
+            try:
+                message = binascii.unhexlify(message)
+            except Exception as e:
+                logger.error("could not get m: %s" % e)
 
         if len(public_key) == 33:
             public_key = bitcoin.decompress(public_key)
@@ -157,7 +157,7 @@ class Crypto(object):
 
         try:
             vk = VerifyingKey.from_string(public_key, curve=NIST256p, hashfunc=hashlib.sha256)
-            res = vk.verify(signature, m, hashfunc=hashlib.sha256)
+            res = vk.verify(signature, message, hashfunc=hashlib.sha256)
             return res
         except Exception as e:
             pass

--- a/tests/test_cryptography.py
+++ b/tests/test_cryptography.py
@@ -227,6 +227,10 @@ class TestCrypto(TestCase):
         verification_result3 = Crypto.VerifySignature(hashdata.decode('utf8'), keypair_signature, binascii.unhexlify(keypair.PublicKey.encode_point(True)))
         self.assertTrue(verification_result3)
 
+        # verify without unhexxing
+        verification_result4 = Crypto.VerifySignature(binascii.unhexlify(hashdata), keypair_signature, binascii.unhexlify(keypair.PublicKey.encode_point(True)), unhex=False)
+        self.assertTrue(verification_result4)
+
         # this should fail because the signature will not match the input data
         verification_result = Crypto.VerifySignature(b'aabb', keypair_signature, keypair.PublicKey)
         self.assertFalse(verification_result)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- make the unhex of a signature message optional in `Crypto.VerifySignature`.  Currently there's no way to pass in a previously unhexxed message to the method, which causes problems for the new opcode `VERIFY`

**How did you solve this problem?**
- made `unhex` optional

**How did you make sure your solution works?**
- test

**Did you add any tests?**
- yes

**Did you run `make lint` and `make coverage`?**
- yes

**Are there any special changes in the code that we should be aware of?**
- no
