### PR TITLE
according to C#, BigInteger(0) is b'\x00'

### DIFF
--- a/neocore/BigInteger.py
+++ b/neocore/BigInteger.py
@@ -15,6 +15,9 @@ class BigInteger(int):
         return super(BigInteger, self).__eq__(other)
 
     def ToByteArray(self, signed=True):
+        if self == 0:
+            return b'\x00'
+
         if self < 0:
             return self.to_bytes(1 + ((self.bit_length() + 7) // 8), byteorder='little', signed=True)
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
I solves issue #49 
**How did you solve this problem?**
I used Eco platform (neocompiler.io) to test both networks simultaneously (Python and C#)
**How did you make sure your solution works?**
I also tested locally.
**Did you add any tests?**
I tested locally.
**Did you run `make lint` and `make coverage`?**
No.
**Are there any special changes in the code that we should be aware of?**
No.