### PR TITLE
Add Size() methods

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.4.11 (2018-07-04)
+-------------------
+* Added ``Size()`` method to `ECPoint` and `Fixed8` class.
+
+
 0.4.10 (2018-06-25)
 -------------------
 * Updated requirements: pycryptome

--- a/neocore/Cryptography/ECCurve.py
+++ b/neocore/Cryptography/ECCurve.py
@@ -431,6 +431,12 @@ class EllipticCurve:
         def IsInfinity(self):
             return True if self == self.curve.Infinity else False
 
+        def Size(self):
+            if self.IsInfinity:
+                return 1
+            else:
+                return 33
+
         def encode_point(self, compressed=True, endian='little'):
 
             if self.IsInfinity:

--- a/neocore/Fixed8.py
+++ b/neocore/Fixed8.py
@@ -143,3 +143,6 @@ class Fixed8:
 
     def __str__(self):
         return self.ToString()
+
+    def Size(self):
+        return 8

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -109,8 +109,8 @@ class Fixed8TestCase(TestCase):
         f8 = Fixed8.TryParse(123.123)
         f8 = Fixed8.TryParse(123)
 
-        self.assertEqual(f8, 8)
-        
+        self.assertEqual(f8.Size(), 8)
+
         # with self.assertRaises(Exception):
         self.assertEqual(Fixed8.TryParse("foo"), None)
         self.assertEqual(Fixed8.TryParse(-1, require_positive=True), None)

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -109,6 +109,8 @@ class Fixed8TestCase(TestCase):
         f8 = Fixed8.TryParse(123.123)
         f8 = Fixed8.TryParse(123)
 
+        self.assertEqual(f8, 8)
+        
         # with self.assertRaises(Exception):
         self.assertEqual(Fixed8.TryParse("foo"), None)
         self.assertEqual(Fixed8.TryParse(-1, require_positive=True), None)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
for resolving https://github.com/CityOfZion/neo-python/issues/427 some core methods require a `Size()` method.

**How did you solve this problem?**
Add size method.

**How did you make sure your solution works?**
make test

**Did you add any tests?**
yes

**Did you run `make lint` and `make coverage`?**
yes

**Are there any special changes in the code that we should be aware of?**
no