### PR TITLE
Update test_numbers for BigInteger

### DIFF
--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -254,6 +254,10 @@ class BigIntegerTestCase(TestCase):
         b3ba = b3.ToByteArray()
         self.assertEqual(b3ba, b'\x80\x00')
 
+        b4 = BigInteger(0)
+        b4ba = b4.ToByteArray()
+        self.assertEqual(b4ba, b'\x00')
+
     def test_big_integer_frombytes(self):
         b1 = BigInteger(8972340892734890723)
         ba = b1.ToByteArray()


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
This adds a test for BigInteger response to 0
This PR is in response to @ixje [comment](https://github.com/CityOfZion/neo-python-core/issues/47#issuecomment-393466923)
This should help solve issue #47 

**How did you solve this problem?**
Added the test for BigInteger response to 0

**How did you make sure your solution works?**
Tested it

**Did you add any tests?**
Yes, see above

**Did you run `make lint` and `make coverage`?**
Yes

**Are there any special changes in the code that we should be aware of?**
No