### PR TITLE
Change BigInteger divisor operation to use floordiv rather than truediv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
   - git clone https://github.com/CityOfZion/neo-python.git
   - cd neo-python
   - git checkout origin/development -b development
-  - pip install -r requirements.txt
+  - pip install -e .
   - yes | pip uninstall neocore
   - pip install -e ../
   - python -m unittest discover neo

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.5.1-dev (in progress)
 -----------------------
-* ...
+* Change BigInteger divisor operation to use floordiv rather than truediv
 
 
 0.5.0 (2018-08-21)

--- a/neocore/BigInteger.py
+++ b/neocore/BigInteger.py
@@ -51,7 +51,7 @@ class BigInteger(int):
         return BigInteger(super(BigInteger, self).__floordiv__(*args, **kwargs))
 
     def __truediv__(self, *args, **kwargs):  # real signature unknown
-        return BigInteger(super(BigInteger, self).__truediv__(*args, **kwargs))
+        return BigInteger(super(BigInteger, self).__floordiv__(*args, **kwargs))
 
 
 ZERO = BigInteger(0)

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -229,6 +229,16 @@ class BigIntegerTestCase(TestCase):
         self.assertIsInstance(b3, BigInteger)
         self.assertEqual(b3, 1000000)
 
+    def test_big_integer_div2(self):
+        b1 = BigInteger(41483775933600000000)
+        b2 = BigInteger(414937759336)
+
+        b3 = b1 / b2
+        b4 = b1 // b2
+        self.assertIsInstance(b3, BigInteger)
+        self.assertEqual(b3, 99975899)
+        self.assertEqual(b4, b3)
+
     def test_big_integer_float(self):
         b1 = BigInteger(5505.001)
         b2 = BigInteger(55055.999)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- Fixes issue identified by @hal0x2328 here: https://github.com/CityOfZion/neo-python/issues/565

**How did you solve this problem?**
- Change BigInteger division behavior to use a `floordiv` operation rather than `truediv`

**How did you make sure your solution works?**
- Added test 

**Did you add any tests?**
- Yes

**Did you run `make lint` and `make coverage`?**
- Yes

**Are there any special changes in the code that we should be aware of?**
- No